### PR TITLE
Indicate options in the executable

### DIFF
--- a/en/scripts.md
+++ b/en/scripts.md
@@ -15,7 +15,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/path_to_executable/xteve 
+ExecStart=/path_to_executable/xteve [-options]
 ExecReload=/usr/bin/killall xteve
 ExecStop=/usr/bin/killall xteve
 KillMode=process


### PR DESCRIPTION
I added a note in the script to let folks know that options can be included in the ExecStart parameter. Eg: ExecStart=/home/your_user/xTeVe/us/xteve -config /home/your_user/xTeVe/ -port 34401